### PR TITLE
Collaborative REPL: Use caller id to name shared REPL variables

### DIFF
--- a/src/types.mo
+++ b/src/types.mo
@@ -117,6 +117,7 @@ public module Eval {
   };
 
   public type Name = {
+    #blob: Blob; // e.g., for caller ids
     #text: Text;
     #nat: Nat;
     #tagTup: (Name, [Name]);

--- a/src/types.mo
+++ b/src/types.mo
@@ -203,6 +203,7 @@ public module Eval {
 
   public func nameEq(n1:Name, n2:Name) : Bool {
     switch (n1, n2) {
+    case (#blob(b1), #blob(b2)) { b1 == b2 };
     case (#nat(n1), #nat(n2)) { n1 == n2 };
     case (#text(t1), #text(t2)) { t1 == t2 };
     case (#tagTup(tag1, tup1), #tagTup(tag2, tup2)) {


### PR DESCRIPTION
Uses latest Motoko/SDK features to name shared REPL variables by the caller-chosen ID, in addition to whatever name they choose.

Pro: name choices do not clash across users, but everyone can see everyone's defined variables.  It gives the basic feel of a whiteboard for shared data and interdependent computations.

Con: there's probably a more useful way to structure the environment, around "namespaces" with a projection operation, etc.  OTOH, that can come later, and this already demonstrates the basic idea of sharing a REPL.