### PR TITLE
Flag to control logging

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,7 +1,10 @@
 {
     "canisters": {
-        "cleanSheets": {
+        "cleanSheetsExcelTest": {
             "main": "test/simpleExcelEmulation.mo"
+        },
+        "cleanSheetsAdaptonTest": {
+            "main": "test/simpleAdaptonDivByZero.mo"
         }
     },
     "defaults": {

--- a/src/types.mo
+++ b/src/types.mo
@@ -314,6 +314,7 @@ public module Adapton {
     var stack: Stack;
     var store: Store;
     // logging for debugging; not essential for other state:
+    var logFlag: Bool;
     var logBuf: LogEventBuf;
     var logStack: LogBufStack;
   };

--- a/test/simpleAdaptonDivByZero.mo
+++ b/test/simpleAdaptonDivByZero.mo
@@ -25,7 +25,7 @@ still pictures from the talk.
 actor SimpleAdaptonDivByZero {
 
   public func go() {
-    let ctx : T.Adapton.Context = A.init();
+    let ctx : T.Adapton.Context = A.init(true);
 
     // "cell 1 holds 42":
     let cell1 : T.Adapton.NodeId = assertOkPut(A.put(ctx, #nat(1), #nat(42)));
@@ -205,4 +205,4 @@ actor SimpleAdaptonDivByZero {
   };
 };
 
-SimpleAdaptonDivByZero.go();
+//SimpleAdaptonDivByZero.go();

--- a/test/simpleExcelEmulation.mo
+++ b/test/simpleExcelEmulation.mo
@@ -24,7 +24,7 @@ actor simpleExcelEmulation {
         ]);
 
     // Adapton maintains our dependence graph
-    let actx : T.Adapton.Context = A.init();
+    let actx : T.Adapton.Context = A.init(true);
 
     // create the initial Sheet datatype from the DSL expression above
     let s : T.Sheet.Sheet = {


### PR DESCRIPTION
The correctness tests use the log, but performance tests (and production) will not.